### PR TITLE
feat: ヘッダーにGoogle Form問い合わせボタンを追加

### DIFF
--- a/src/app/card/page.tsx
+++ b/src/app/card/page.tsx
@@ -6,6 +6,7 @@ import { createClient } from "@/lib/supabase/client";
 import { PointCardAnimated } from "@/components/point-card/PointCardAnimated";
 import { BottomNav } from "@/components/BottomNav";
 import { Button } from "@/components/ui/button";
+import { Header } from "@/components/Header";
 import { useEffect, useRef, useState } from "react";
 import { getStampCount, resetStamps, getPrevCardPoints, setPrevCardPoints } from "@/lib/stampBadge";
 import { PTS_PER_SQUARE } from "@/core/pointCard";
@@ -127,9 +128,7 @@ export default function CardPage() {
 	return (
 		<div className="min-h-screen bg-gray-50 pb-20">
 			<div className="max-w-md mx-auto">
-				<div className="px-4 py-4 bg-white border-b border-gray-200">
-					<h1 className="text-xl font-bold text-gray-900">ポイントカード</h1>
-				</div>
+				<Header />
 				<div className="px-4 pt-6">
 					{profile && (
 						<>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ export const dynamic = "force-dynamic";
 import { createClient } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
 import { BottomNav } from "@/components/BottomNav";
+import { Header } from "@/components/Header";
 import { useRoutineInit } from "@/hooks/useRoutineInit";
 import { calcRoutinePoints, getJSTDate, getJSTWeek } from "@/core/tasks";
 import { addStamp, removeStamp } from "@/lib/stampBadge";
@@ -218,11 +219,6 @@ export default function Home() {
 		await fetchAll();
 	};
 
-	const handleLogout = async () => {
-		await supabase.auth.signOut();
-		window.location.href = "/login";
-	};
-
 	const todayTasks = tasks.filter((t) => t.type === "daily_routine" || t.type === "urgent");
 	const weeklyTasks = tasks.filter((t) => t.type === "weekly_routine");
 	const somedayTasks = tasks.filter((t) => t.type === "someday");
@@ -239,13 +235,7 @@ export default function Home() {
 	return (
 		<div className="min-h-screen bg-gray-50 pb-20">
 			<div className="max-w-md mx-auto">
-				{/* Header */}
-				<div className="flex items-center justify-between px-4 py-4 bg-white border-b border-gray-200">
-					<h1 className="text-xl font-bold text-gray-900">mypoint</h1>
-					<Button variant="outline" size="sm" onClick={handleLogout}>
-						ログアウト
-					</Button>
-				</div>
+				<Header />
 
 				{/* Tabs */}
 				<div className="flex bg-white border-b border-gray-200">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Mail } from "lucide-react";
+
+const FEEDBACK_URL = "https://forms.gle/8v4SscVj5ZthXj6J9";
+
+export function Header() {
+	const supabase = createClient();
+
+	const handleLogout = async () => {
+		await supabase.auth.signOut();
+		window.location.href = "/login";
+	};
+
+	return (
+		<div className="flex items-center justify-between px-4 py-4 bg-white border-b border-gray-200">
+			<h1 className="text-xl font-bold text-gray-900">mypoint</h1>
+			<div className="flex items-center gap-2">
+				<a
+					href={FEEDBACK_URL}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="p-2 text-gray-400 hover:text-gray-600"
+					aria-label="お問い合わせ"
+				>
+					<Mail size={20} />
+				</a>
+				<Button variant="outline" size="sm" onClick={handleLogout}>
+					ログアウト
+				</Button>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

- 共通 `Header` コンポーネントを新規作成
  - Mail アイコンボタン（クリックで Google Form を新規タブで開く）
  - ログアウトボタン
- ホームページ・カードページ両方に共通 Header を適用

## Test plan

- [x] ホームページのヘッダーに Mail アイコンが表示される
- [x] カードページのヘッダーに Mail アイコンが表示される
- [x] Mail アイコンをタップすると Google Form が新規タブで開く
- [x] ログアウトボタンが引き続き動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)