### PR TITLE
test: weekly_countスロット機能の単体テスト追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { BottomNav } from "@/components/BottomNav";
 import { Header } from "@/components/Header";
 import { useRoutineInit } from "@/hooks/useRoutineInit";
-import { calcRoutinePoints, getJSTDate, getJSTWeek } from "@/core/tasks";
+import { calcRoutinePoints, formatSlotDate, getJSTDate, getJSTWeek } from "@/core/tasks";
 import { addStamp, removeStamp } from "@/lib/stampBadge";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -714,7 +714,3 @@ function WeeklyTaskSection({ title, tasks, completions, onSlotComplete, onSlotUn
 	);
 }
 
-function formatSlotDate(dateStr: string): string {
-	const [, m, d] = dateStr.split("-");
-	return `${Number(m)}/${Number(d)}`;
-}

--- a/src/core/tasks.test.ts
+++ b/src/core/tasks.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { calcRoutinePoints, getJSTDate, getJSTWeek } from "./tasks";
+import { calcRoutinePoints, formatSlotDate, getJSTDate, getJSTWeek } from "./tasks";
 
 describe("calcRoutinePoints", () => {
 	it("1タスクのとき 100pt になる", () => {
@@ -28,6 +28,32 @@ describe("calcRoutinePoints", () => {
 
 	it("負数のとき 0pt になる", () => {
 		expect(calcRoutinePoints(-1)).toBe(0);
+	});
+
+	it("週スロット合計4（3+1）のとき 25pt になる", () => {
+		expect(calcRoutinePoints(4)).toBe(25);
+	});
+
+	it("週スロット合計6（3+2+1）のとき 16pt になる（floor）", () => {
+		expect(calcRoutinePoints(6)).toBe(16);
+	});
+});
+
+describe("formatSlotDate", () => {
+	it("YYYY-MM-DD を M/D に変換する", () => {
+		expect(formatSlotDate("2026-02-25")).toBe("2/25");
+	});
+
+	it("月・日が1桁のとき先頭ゼロを除去する", () => {
+		expect(formatSlotDate("2026-01-01")).toBe("1/1");
+	});
+
+	it("月が2桁・日が1桁のとき正しく変換する", () => {
+		expect(formatSlotDate("2026-10-05")).toBe("10/5");
+	});
+
+	it("月・日ともに2桁のとき正しく変換する", () => {
+		expect(formatSlotDate("2026-12-31")).toBe("12/31");
 	});
 });
 

--- a/src/core/tasks.ts
+++ b/src/core/tasks.ts
@@ -14,6 +14,11 @@ export function getJSTDate(): string {
 		.replace(/\//g, "-");
 }
 
+export function formatSlotDate(dateStr: string): string {
+	const [, m, d] = dateStr.split("-");
+	return `${Number(m)}/${Number(d)}`;
+}
+
 export function getJSTWeek(): string {
 	const now = new Date(
 		new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" }),


### PR DESCRIPTION
## Summary

- `formatSlotDate` を `page.tsx` から `src/core/tasks.ts` に移動し export
- `formatSlotDate` の単体テスト 4 件追加
- `calcRoutinePoints` に週スロット用途のテストケース 2 件追加（totalSlots=4, 6）

## Test plan

- [ ] `npm test` が全 33 件 pass すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)