### PR TITLE
fix: ミドルウェアが動いていなかった問題を修正・セッション永続化

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,7 @@
 import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
 
-export async function proxy(request: NextRequest) {
+export async function middleware(request: NextRequest) {
 	let supabaseResponse = NextResponse.next({ request });
 
 	const supabase = createServerClient(
@@ -26,11 +26,14 @@ export async function proxy(request: NextRequest) {
 	);
 
 	const {
-		data: { user },
-	} = await supabase.auth.getUser();
+		data: { session },
+	} = await supabase.auth.getSession();
 
-	// 未ログインの場合、/login 以外へのアクセスをリダイレクト
-	if (!user && !request.nextUrl.pathname.startsWith("/login") && !request.nextUrl.pathname.startsWith("/auth")) {
+	if (
+		!session &&
+		!request.nextUrl.pathname.startsWith("/login") &&
+		!request.nextUrl.pathname.startsWith("/auth")
+	) {
 		const url = request.nextUrl.clone();
 		url.pathname = "/login";
 		return NextResponse.redirect(url);


### PR DESCRIPTION
## Summary

- `src/proxy.ts` → `src/middleware.ts` にリネーム（Next.jsはこのファイル名でないとミドルウェアとして認識しない）
- `getUser()` → `getSession()` に変更し、リクエストごとの Supabase API コールを削減

## 背景

`proxy.ts` という名前ではNext.jsにミドルウェアとして認識されず、以下が機能していなかった：
- サーバーサイドのセッション更新（トークンリフレッシュ）
- 未ログイン時の `/login` リダイレクト

## トレードオフ

`getSession()` はクッキーからJWTをローカルで読むだけでSupabaseサーバーへの問い合わせを行わない。JWTの改ざんリスクはあるが、RLSがDBを保護しているため個人用途（最大20ユーザー）では許容できる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)