### PR TITLE
fix: middleware.tsをproxy.tsに戻しexport名をproxyに修正

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,7 @@
 import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
 	let supabaseResponse = NextResponse.next({ request });
 
 	const supabase = createServerClient(


### PR DESCRIPTION
## Summary

- `src/middleware.ts` → `src/proxy.ts` に戻す（Next.js 16 の正しいファイル規約）
- export 関数名を `middleware` → `proxy` に変更

## 背景

PR #19 で `proxy.ts` → `middleware.ts` にリネームしたが、Next.js 16 では `proxy.ts` が正しい規約で `middleware.ts` は非推奨。ビルド時に以下の警告が出ていた：

```
⚠ The "middleware" file convention is deprecated. Please use "proxy" instead.
```

## 変更内容

`getSession()` への変更（PR #19）は維持しつつ、ファイル名と関数名のみ修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)