### PR TITLE
fix: middleware.tsに戻してミドルウェアを正常に機能させる

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,7 @@
 import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
 
-export async function proxy(request: NextRequest) {
+export async function middleware(request: NextRequest) {
 	let supabaseResponse = NextResponse.next({ request });
 
 	const supabase = createServerClient(


### PR DESCRIPTION
## Summary

- `src/proxy.ts` → `src/middleware.ts` にリネーム
- エクスポート名を `proxy` → `middleware` に修正

## 背景

2/25のPR #19でいったん修正済みだったが、2/23に発生していた別原因のVercelエラーと混同して不要なリバートを実施してしまった。

- 2/23のVercelエラー: 認証ページのプリレンダリング問題（`82d190e`で修正済み）
- middleware.tsへの変更後のデプロイは全てReady → エラーとは無関係

## 影響

ミドルウェアが動いていない状態では以下が機能しない：
- サーバーサイドのセッション更新（トークンリフレッシュ）
- 未ログイン時の `/login` リダイレクト（クライアント側で補完されていたが不安定）
- スマホでブラウザをバックグラウンドにした際の認証切れの一因

🤖 Generated with [Claude Code](https://claude.com/claude-code)