### PR TITLE
fix: proxy.tsのエクスポート名をproxyに修正（ビルドエラー解消）

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,7 @@
 import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
 	let supabaseResponse = NextResponse.next({ request });
 
 	const supabase = createServerClient(


### PR DESCRIPTION
## Summary

`proxy.ts` のエクスポート名を `middleware` → `proxy` に修正。

## 背景

PR #22 で `proxy.ts` + `export function middleware` の組み合わせにしたところ、
Next.js 16 のビルドでエラーが発生した。

```
Proxy is missing expected function export name
To fix it: Ensure this file has either a default or "proxy" function export.
```

Next.js 16 の正しい規約：
- ファイル名: `proxy.ts`
- エクスポート名: `proxy`（または default）

🤖 Generated with [Claude Code](https://claude.com/claude-code)