### PR TITLE
feat: バックグラウンド復帰時のセッション再取得（スマホ認証切れ対策）

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Toaster } from "sonner";
+import { AuthRefresher } from "@/components/AuthRefresher";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -30,6 +31,7 @@ export default function RootLayout({
       >
         {children}
         <Toaster position="top-center" />
+        <AuthRefresher />
       </body>
     </html>
   );

--- a/src/components/AuthRefresher.tsx
+++ b/src/components/AuthRefresher.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { createClient } from "@/lib/supabase/client";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+export function AuthRefresher() {
+	const supabase = createClient();
+	const router = useRouter();
+
+	useEffect(() => {
+		const handleVisibilityChange = async () => {
+			if (document.visibilityState === "visible") {
+				const {
+					data: { session },
+				} = await supabase.auth.getSession();
+				if (!session) {
+					router.push("/login");
+				}
+			}
+		};
+
+		document.addEventListener("visibilitychange", handleVisibilityChange);
+		return () =>
+			document.removeEventListener("visibilitychange", handleVisibilityChange);
+	}, [supabase, router]);
+
+	return null;
+}


### PR DESCRIPTION
## Summary

- `AuthRefresher` コンポーネントを新規作成し `layout.tsx` に追加
- `visibilitychange` イベントでフォアグラウンド復帰を検知
- 復帰時に `supabase.auth.getSession()` でトークンをリフレッシュ
- セッション切れの場合は `/login` へリダイレクト

## 背景

スマホでブラウザをバックグラウンドにすると以下の問題が発生していた：

1. モバイルブラウザがバックグラウンド中にJSタイマーを停止
2. auto-refreshタイマーが止まりアクセストークン（1時間）が期限切れに
3. 復帰時はbfcacheからページが復元されるためミドルウェアが動かない
4. セッション更新が行われず認証切れとなる

## 動作

```
バックグラウンド → フォアグラウンド復帰
  → visibilitychange: "visible"
  → getSession() でリフレッシュトークンを使いアクセストークンを更新
  → セッションなし → /login へ
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)