### PR TITLE
fix: AuthRefresherをrouter.refresh()方式に変更（iOS Safari認証切れ修正）

### DIFF
--- a/src/components/AuthRefresher.tsx
+++ b/src/components/AuthRefresher.tsx
@@ -1,40 +1,34 @@
 "use client";
 
-import { createClient } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 
 export function AuthRefresher() {
-	const supabase = createClient();
 	const router = useRouter();
 
 	useEffect(() => {
-		const refresh = async () => {
-			const {
-				data: { session },
-			} = await supabase.auth.getSession();
-			if (!session) {
-				router.push("/login");
-			}
-		};
-
 		// iOS Safari: bfcacheからの復帰はvisibilitychangeが発火しないためpageshowを使う
 		const handlePageShow = (e: PageTransitionEvent) => {
-			if (e.persisted) refresh();
+			if (e.persisted) router.refresh();
 		};
 
 		// Android Chromeなどその他のブラウザ向け
 		const handleVisibilityChange = () => {
-			if (document.visibilityState === "visible") refresh();
+			if (document.visibilityState === "visible") router.refresh();
 		};
+
+		// 保険としてfocusも監視
+		const handleFocus = () => router.refresh();
 
 		window.addEventListener("pageshow", handlePageShow);
 		document.addEventListener("visibilitychange", handleVisibilityChange);
+		window.addEventListener("focus", handleFocus);
 		return () => {
 			window.removeEventListener("pageshow", handlePageShow);
 			document.removeEventListener("visibilitychange", handleVisibilityChange);
+			window.removeEventListener("focus", handleFocus);
 		};
-	}, [supabase, router]);
+	}, [router]);
 
 	return null;
 }


### PR DESCRIPTION
## Summary

`AuthRefresher` の認証チェック方式を `getSession()` + クライアントリダイレクトから `router.refresh()` に変更。

## 問題

`pageshow` 発火直後はネットワーク未復帰のため `getSession()` のリフレッシュが失敗し、セッションなし判定 → 即 `/login` リダイレクトが発生していた。

## 変更後の動作

```
bfcache復帰 / visibilitychange / focus
 → router.refresh() でサーバーへリクエスト
 → ミドルウェアがセッションチェック・トークンリフレッシュ
 → 有効 → そのまま表示
 → 無効 → ミドルウェアが /login へリダイレクト
```

認証判断をクライアントで行わずミドルウェアに委譲することで、ネットワーク復帰タイミングの問題を回避。

## 監視イベント

- `pageshow (persisted)`: iOS Safari のbfcache復帰
- `visibilitychange`: Android Chromeなど他ブラウザ
- `focus`: 保険

🤖 Generated with [Claude Code](https://claude.com/claude-code)