### PR TITLE
fix: リフレッシュトークン競合エラーを修正（デバウンス追加）

### DIFF
--- a/src/components/AuthRefresher.tsx
+++ b/src/components/AuthRefresher.tsx
@@ -7,23 +7,34 @@ export function AuthRefresher() {
 	const router = useRouter();
 
 	useEffect(() => {
+		let timer: ReturnType<typeof setTimeout> | null = null;
+
+		const refresh = () => {
+			if (timer) clearTimeout(timer);
+			timer = setTimeout(() => {
+				router.refresh();
+				timer = null;
+			}, 200);
+		};
+
 		// iOS Safari: bfcacheからの復帰はvisibilitychangeが発火しないためpageshowを使う
 		const handlePageShow = (e: PageTransitionEvent) => {
-			if (e.persisted) router.refresh();
+			if (e.persisted) refresh();
 		};
 
 		// Android Chromeなどその他のブラウザ向け
 		const handleVisibilityChange = () => {
-			if (document.visibilityState === "visible") router.refresh();
+			if (document.visibilityState === "visible") refresh();
 		};
 
 		// 保険としてfocusも監視
-		const handleFocus = () => router.refresh();
+		const handleFocus = () => refresh();
 
 		window.addEventListener("pageshow", handlePageShow);
 		document.addEventListener("visibilitychange", handleVisibilityChange);
 		window.addEventListener("focus", handleFocus);
 		return () => {
+			if (timer) clearTimeout(timer);
 			window.removeEventListener("pageshow", handlePageShow);
 			document.removeEventListener("visibilitychange", handleVisibilityChange);
 			window.removeEventListener("focus", handleFocus);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -25,9 +25,13 @@ export async function proxy(request: NextRequest) {
 		},
 	);
 
-	const {
-		data: { session },
-	} = await supabase.auth.getSession();
+	let session = null;
+	try {
+		const { data } = await supabase.auth.getSession();
+		session = data.session;
+	} catch {
+		// refresh_token_not_found など無効なトークンはセッションなしとして扱う
+	}
 
 	if (
 		!session &&


### PR DESCRIPTION
## 問題

`router.refresh()` が `pageshow` / `visibilitychange` / `focus` から同時に呼ばれ、
Supabase のトークンローテーションが競合して `refresh_token_not_found` エラーが発生していた。

## 修正内容

**AuthRefresher**: 200ms デバウンスを追加し、同時発火を1回のリクエストにまとめる

**proxy.ts**: `getSession()` のエラーをキャッチしてセッションなしとして扱う
- エラー時もクラッシュせず `/login` へ安全にリダイレクト

🤖 Generated with [Claude Code](https://claude.com/claude-code)