### PR TITLE
fix: AuthRefresherをwindow.location.reload()方式に変更

### DIFF
--- a/src/components/AuthRefresher.tsx
+++ b/src/components/AuthRefresher.tsx
@@ -1,45 +1,18 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 
 export function AuthRefresher() {
-	const router = useRouter();
-
 	useEffect(() => {
-		let timer: ReturnType<typeof setTimeout> | null = null;
-
-		const refresh = () => {
-			if (timer) clearTimeout(timer);
-			timer = setTimeout(() => {
-				router.refresh();
-				timer = null;
-			}, 200);
-		};
-
-		// iOS Safari: bfcacheからの復帰はvisibilitychangeが発火しないためpageshowを使う
 		const handlePageShow = (e: PageTransitionEvent) => {
-			if (e.persisted) refresh();
+			if (e.persisted) {
+				window.location.reload();
+			}
 		};
-
-		// Android Chromeなどその他のブラウザ向け
-		const handleVisibilityChange = () => {
-			if (document.visibilityState === "visible") refresh();
-		};
-
-		// 保険としてfocusも監視
-		const handleFocus = () => refresh();
 
 		window.addEventListener("pageshow", handlePageShow);
-		document.addEventListener("visibilitychange", handleVisibilityChange);
-		window.addEventListener("focus", handleFocus);
-		return () => {
-			if (timer) clearTimeout(timer);
-			window.removeEventListener("pageshow", handlePageShow);
-			document.removeEventListener("visibilitychange", handleVisibilityChange);
-			window.removeEventListener("focus", handleFocus);
-		};
-	}, [router]);
+		return () => window.removeEventListener("pageshow", handlePageShow);
+	}, []);
 
 	return null;
 }


### PR DESCRIPTION
## Summary

bfcache復元時のセッション復帰を `router.refresh()` から `window.location.reload()` に変更。

## 問題

`router.refresh()` による RSC リクエストが iOS Safari で cookies を正しく付与できず、ミドルウェアがセッションなしと判断して `/login` へリダイレクトしていた。ログ分析から 50ms 以内にリダイレクトが発生しており、debounce (200ms) より速いことからも `router.refresh()` とは別の原因だと確認。

## 変更内容

- `pageshow(persisted=true)` のみ監視（bfcache 復元の確実な検知）
- `window.location.reload()` で完全なブラウザナビゲーションを実施
  - cookies が確実に付与される
  - ミドルウェアが正しくセッションをリフレッシュできる
- `visibilitychange` / `focus` ハンドラを削除（トークン競合の原因）

🤖 Generated with [Claude Code](https://claude.com/claude-code)