### PR TITLE
fix: sessionStorageフラグでbfcache reloadループを防止

### DIFF
--- a/src/components/AuthRefresher.tsx
+++ b/src/components/AuthRefresher.tsx
@@ -4,8 +4,11 @@ import { useEffect } from "react";
 
 export function AuthRefresher() {
 	useEffect(() => {
+		sessionStorage.removeItem("bfcache_reloading");
+
 		const handlePageShow = (e: PageTransitionEvent) => {
-			if (e.persisted) {
+			if (e.persisted && !sessionStorage.getItem("bfcache_reloading")) {
+				sessionStorage.setItem("bfcache_reloading", "1");
 				window.location.reload();
 			}
 		};


### PR DESCRIPTION
## 問題

`window.location.reload()` 後も iOS Safari が `pageshow.persisted=true` を発火し続け、
reloadループが発生していた。複数のリロードがトークンローテーションを連続で呼び出し
`refresh_token_not_found` → `/login` リダイレクトという流れ。

## 修正

`sessionStorage` フラグで reload を1回のみに制御する。

- 通常ロード（`persisted=false`）時: フラグをクリア
- bfcache復元（`persisted=true`）時: フラグがなければ `reload()` してフラグを立てる
- bfcache復元時は sessionStorage も bfcache 時点の状態に復元されるため、フラグなし → reload → フラグあり → 次回はスキップ、という動作になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)