### PR TITLE
fix: iOS Safari bfcache/リロード時の認証切れ対策

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,10 +1,12 @@
 import { PointCardDemo } from "@/components/landing/PointCardDemo";
 import { GoogleLoginButton } from "@/components/landing/GoogleLoginButton";
 import { Ranking } from "@/components/landing/Ranking";
+import { AuthRedirect } from "@/components/AuthRedirect";
 
 export default function LoginPage() {
 	return (
 		<div className="min-h-screen bg-gray-50 py-8 sm:py-12 px-4">
+			<AuthRedirect />
 			<div className="max-w-md mx-auto space-y-6 sm:space-y-8">
 				<div className="text-center space-y-2">
 					<h1 className="text-3xl font-bold text-gray-900">mypoint</h1>

--- a/src/components/AuthRedirect.tsx
+++ b/src/components/AuthRedirect.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { createClient } from "@/lib/supabase/client";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+export function AuthRedirect() {
+	const router = useRouter();
+
+	useEffect(() => {
+		const check = async () => {
+			try {
+				const supabase = createClient();
+				const { data } = await supabase.auth.getUser();
+				if (data.user) router.replace("/");
+			} catch {
+				// 認証チェック失敗時はそのままログインページを表示
+			}
+		};
+
+		check();
+
+		const handlePageShow = (e: PageTransitionEvent) => {
+			if (e.persisted) check();
+		};
+
+		window.addEventListener("pageshow", handlePageShow);
+		return () => window.removeEventListener("pageshow", handlePageShow);
+	}, [router]);
+
+	return null;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -43,6 +43,12 @@ export async function proxy(request: NextRequest) {
 		return NextResponse.redirect(url);
 	}
 
+	if (session && request.nextUrl.pathname === "/login") {
+		const url = request.nextUrl.clone();
+		url.pathname = "/";
+		return NextResponse.redirect(url);
+	}
+
 	return supabaseResponse;
 }
 


### PR DESCRIPTION
## Summary

- `proxy.ts`: 認証済みユーザーが `/login` にアクセスした場合、`/` へリダイレクト
- `AuthRedirect` コンポーネント: `/login` ページで bfcache 復元（`pageshow.persisted=true`）を検知し、認証済みなら `router.replace('/')` で遷移

## 背景

iOS Safari で「ログイン→バックグラウンド→アプリに戻る（リロード発生）→ランディングページ」の問題が発生していた。

原因として考えられる2パターン：
1. **フルリロード**: iOS が Safari プロセスをキルして再起動 → `/` にリクエストするが何らかの理由でセッションが見つからず `/login` へリダイレクト → この修正後は `/login` でも認証済みなら `/` に戻す
2. **bfcache 復元**: iOS が bfcache でログイン前の `/login` ページ状態を復元 → `AuthRedirect` の `pageshow.persisted` ハンドラが認証チェックして `/` へ遷移

## 追加で必要な対応（ユーザー側）

Supabase ダッシュボードで JWT 有効期限を延長する：
- Authentication → Settings → JWT expiry: `3600` → `28800`（8時間）