### PR TITLE
feat: ポイントカードを24×24ドット絵リビール方式に変更

### DIFF
--- a/src/app/card/page.tsx
+++ b/src/app/card/page.tsx
@@ -164,26 +164,39 @@ export default function CardPage() {
 						</Button>
 						{rewards.length > 0 && (
 							<div className="space-y-2">
-								{rewards.map((reward) => (
+								{rewards.map((reward) => {
+									const pts = profile?.points_total ?? 0;
+									const progress = Math.min((pts / reward.points) * 100, 100);
+									const achieved = pts >= reward.points;
+									return (
 									<div
 										key={reward.id}
-										className="flex items-center bg-white rounded-lg border border-gray-200"
+										className="bg-white rounded-lg border border-gray-200 overflow-hidden"
 									>
-										<div className="flex items-center gap-3 flex-1 px-4 py-3">
+										<div className="flex items-center gap-3 px-4 pt-3 pb-2">
 											<span className="text-lg">🎁</span>
 											<span className="flex-1 text-sm text-gray-800">{reward.label}</span>
-											<span className="text-xs text-indigo-500 font-medium">{reward.points}pt</span>
+											<span className={`text-xs font-medium ${achieved ? "text-green-500" : "text-indigo-500"}`}>
+												{achieved ? "達成！" : `${pts}/${reward.points}pt`}
+											</span>
+											<button
+												type="button"
+												onClick={() => openEdit(reward)}
+												className="text-gray-300 hover:text-gray-500 text-lg leading-none"
+											>
+												…
+											</button>
 										</div>
-										<button
-											type="button"
-											onClick={() => openEdit(reward)}
-											className="px-3 py-3 text-gray-300 hover:text-gray-500 text-lg leading-none"
-										>
-											…
-										</button>
+										<div className="h-1.5 bg-gray-100 mx-4 mb-3 rounded-full overflow-hidden">
+											<div
+												className={`h-full rounded-full transition-all duration-500 ${achieved ? "bg-green-400" : "bg-indigo-400"}`}
+												style={{ width: `${progress}%` }}
+											/>
+										</div>
 									</div>
-								))}
-							</div>
+								);
+							})}
+	</div>
 						)}
 						{rewards.length === 0 && (
 							<p className="text-center text-gray-400 text-sm mt-4">ご褒美を設定するとカードにマイルストーンが表示されます</p>

--- a/src/components/landing/PointCardDemo.tsx
+++ b/src/components/landing/PointCardDemo.tsx
@@ -1,25 +1,25 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { PTS_PER_SQUARE, calcPointCard, type Reward } from "@/core/pointCard";
+import { PTS_PER_SQUARE } from "@/core/pointCard";
 import { PointCardAnimated } from "@/components/point-card/PointCardAnimated";
+import type { Reward } from "@/core/pointCard";
 
 const DEMO_REWARDS: Reward[] = [
-	{ id: "1", label: "ケーキ", points: 200 },
-	{ id: "2", label: "映画", points: 500 },
+	{ id: "1", label: "ケーキ", points: 50 },
+	{ id: "2", label: "映画", points: 120 },
 ];
 
-const STEP_MS = 700;
-const ANIM_MS = 500;
+const DEMO_STEPS = 40;
+const STEP_MS = 600;
+const ANIM_MS = 400;
 const REWARD_ANIM_MS = 800;
-const RESET_MS = 1500;
 
-const REWARD_INDICES = new Set(
+const REWARD_FILL_POSITIONS = new Set(
 	DEMO_REWARDS.map((r) => Math.ceil(r.points / PTS_PER_SQUARE) - 1),
 );
 
 export function PointCardDemo() {
-	const { totalSquares } = calcPointCard(0, DEMO_REWARDS);
 	const [filledCount, setFilledCount] = useState(0);
 	const [animatingIndex, setAnimatingIndex] = useState<number | null>(null);
 	const stepRef = useRef(0);
@@ -27,10 +27,10 @@ export function PointCardDemo() {
 	useEffect(() => {
 		const interval = setInterval(() => {
 			const step = stepRef.current;
-			if (step < totalSquares) {
+			if (step < DEMO_STEPS) {
 				setAnimatingIndex(step);
 				setFilledCount(step + 1);
-				const clearDelay = REWARD_INDICES.has(step) ? REWARD_ANIM_MS : ANIM_MS;
+				const clearDelay = REWARD_FILL_POSITIONS.has(step) ? REWARD_ANIM_MS : ANIM_MS;
 				setTimeout(() => setAnimatingIndex(null), clearDelay);
 				stepRef.current = step + 1;
 			} else {
@@ -40,7 +40,7 @@ export function PointCardDemo() {
 		}, STEP_MS);
 
 		return () => clearInterval(interval);
-	}, [totalSquares]);
+	}, []);
 
 	return (
 		<PointCardAnimated

--- a/src/components/point-card/PointCard.tsx
+++ b/src/components/point-card/PointCard.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { type Reward, calcPointCard } from "@/core/pointCard";
 
 type Props = {
@@ -8,61 +7,26 @@ type Props = {
 	rewards: Reward[];
 };
 
-type TooltipState = {
-	reward: Reward;
-	squareIndex: number;
-} | null;
-
 export function PointCard({ currentPoints, rewards }: Props) {
-	const { rows } = calcPointCard(currentPoints, rewards);
-	const [tooltip, setTooltip] = useState<TooltipState>(null);
+	const { squares } = calcPointCard(currentPoints, rewards);
 
 	return (
-		<div className="bg-white rounded-2xl border border-gray-100 p-3 sm:p-6 space-y-1">
-			{rows.map((row, rowIndex) => (
-				<div key={rowIndex} className="grid grid-cols-8 gap-1">
-					{row.squares.map((square, colIndex) => {
-						const squareIndex = rowIndex * 8 + colIndex;
-						const isTooltipOpen = tooltip?.squareIndex === squareIndex;
-
-						if (square.reward) {
-							return (
-								<div key={colIndex} className="relative">
-									<button
-										type="button"
-										className={`w-full aspect-square rounded-sm flex items-center justify-center text-sm ${
-											square.filled
-												? "bg-indigo-500 text-white"
-												: "bg-gray-100 text-gray-400"
-										}`}
-										onClick={() =>
-											setTooltip(isTooltipOpen ? null : { reward: square.reward!, squareIndex })
-										}
-									>
-										🎁
-									</button>
-									{isTooltipOpen && (
-										<div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-10 whitespace-nowrap bg-gray-900 text-white text-xs rounded-lg px-3 py-2 shadow-lg">
-											<p className="font-medium">{square.reward.label}</p>
-											<p className="text-gray-300">{square.reward.points}pt</p>
-											<div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900" />
-										</div>
-									)}
-								</div>
-							);
-						}
-
-						return (
-							<div
-								key={colIndex}
-								className={`aspect-square rounded-sm ${
-									square.filled ? "bg-indigo-500" : "bg-gray-100"
-								}`}
-							/>
-						);
-					})}
-				</div>
-			))}
+		<div className="bg-white rounded-2xl border border-gray-100 p-3 sm:p-4">
+			<div
+				style={{
+					display: "grid",
+					gridTemplateColumns: "repeat(24, minmax(0, 1fr))",
+					gap: "1px",
+				}}
+			>
+				{squares.map((square, i) => (
+					<div
+						key={i}
+						className="aspect-square"
+						style={{ backgroundColor: square.filled ? square.color : "#f3f4f6" }}
+					/>
+				))}
+			</div>
 		</div>
 	);
 }

--- a/src/components/point-card/PointCardAnimated.tsx
+++ b/src/components/point-card/PointCardAnimated.tsx
@@ -7,21 +7,26 @@ import { calcPointCard, PTS_PER_SQUARE, type Reward } from "@/core/pointCard";
 type Props = {
 	currentPoints: number;
 	rewards: Reward[];
-	animatingIndex: number | null;
+	animatingIndex: number | null; // ポイント積み上げによる埋め順位置（0始まり、preOpened除く）
 };
 
 export function PointCardAnimated({ currentPoints, rewards, animatingIndex }: Props) {
-	const { rows } = calcPointCard(currentPoints, rewards);
+	const { squares, fillOrder, preOpened } = calcPointCard(currentPoints, rewards);
 	const squareRefs = useRef<Map<number, HTMLDivElement>>(new Map());
 
-	const rewardIndices = useMemo(
+	const rewardFillPositions = useMemo(
 		() => new Set(rewards.map((r) => Math.ceil(r.points / PTS_PER_SQUARE) - 1)),
 		[rewards],
 	);
 
+	const animatingGridIndex =
+		animatingIndex !== null ? (fillOrder[preOpened + animatingIndex] ?? null) : null;
+
 	useEffect(() => {
-		if (animatingIndex === null || !rewardIndices.has(animatingIndex)) return;
-		const el = squareRefs.current.get(animatingIndex);
+		if (animatingIndex === null || !rewardFillPositions.has(animatingIndex)) return;
+		if (animatingGridIndex === null) return;
+
+		const el = squareRefs.current.get(animatingGridIndex);
 		if (!el) return;
 
 		const rect = el.getBoundingClientRect();
@@ -36,38 +41,34 @@ export function PointCardAnimated({ currentPoints, rewards, animatingIndex }: Pr
 			gravity: 0.9,
 			colors: ["#6366f1", "#818cf8", "#f59e0b", "#fbbf24", "#ec4899", "#34d399"],
 		});
-	}, [animatingIndex, rewardIndices]);
+	}, [animatingIndex, rewardFillPositions, animatingGridIndex]);
 
 	return (
-		<div className="bg-white rounded-2xl border border-gray-100 p-3 sm:p-6 space-y-1">
-			{rows.map((row, rowIndex) => (
-				<div key={rowIndex} className="grid grid-cols-8 gap-1">
-					{row.squares.map((square, colIndex) => {
-						const squareIndex = rowIndex * 8 + colIndex;
-						const isAnimating = animatingIndex === squareIndex;
+		<div className="bg-white rounded-2xl border border-gray-100 p-3 sm:p-4">
+			<div
+				style={{
+					display: "grid",
+					gridTemplateColumns: "repeat(24, minmax(0, 1fr))",
+					gap: "1px",
+				}}
+			>
+				{squares.map((square, gridIndex) => {
+					const isAnimating = gridIndex === animatingGridIndex;
+					const animClass = square.filled && isAnimating ? "animate-stamp" : "";
 
-						let animClass = "";
-						if (square.filled && isAnimating) {
-							animClass = square.reward ? "animate-reward-clear" : "animate-stamp";
-						}
-
-						return (
-							<div
-								key={colIndex}
-								ref={(el) => {
-									if (el) squareRefs.current.set(squareIndex, el);
-									else squareRefs.current.delete(squareIndex);
-								}}
-								className={`aspect-square rounded-sm flex items-center justify-center text-sm ${
-									square.filled ? `bg-indigo-500 ${animClass}` : "bg-gray-100"
-								}`}
-							>
-								{square.reward ? "🎁" : null}
-							</div>
-						);
-					})}
-				</div>
-			))}
+					return (
+						<div
+							key={gridIndex}
+							ref={(el) => {
+								if (el) squareRefs.current.set(gridIndex, el);
+								else squareRefs.current.delete(gridIndex);
+							}}
+							className={`aspect-square ${animClass}`}
+							style={{ backgroundColor: square.filled ? square.color : "#f3f4f6" }}
+						/>
+					);
+				})}
+			</div>
 		</div>
 	);
 }

--- a/src/core/dotArt.test.ts
+++ b/src/core/dotArt.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { getDotArt } from "./dotArt";
+
+const GRID_SIZE = 24;
+const TOTAL_SQUARES = GRID_SIZE * GRID_SIZE; // 576
+
+describe("getDotArt", () => {
+	describe("データ構造", () => {
+		it("colors が 576 件", () => {
+			const { colors } = getDotArt(3);
+			expect(colors).toHaveLength(TOTAL_SQUARES);
+		});
+
+		it("fillOrder が 576 件", () => {
+			const { fillOrder } = getDotArt(3);
+			expect(fillOrder).toHaveLength(TOTAL_SQUARES);
+		});
+
+		it("fillOrder は 0〜575 の各値を1回ずつ含む（完全置換）", () => {
+			const { fillOrder } = getDotArt(3);
+			expect(new Set(fillOrder).size).toBe(TOTAL_SQUARES);
+			expect(Math.min(...fillOrder)).toBe(0);
+			expect(Math.max(...fillOrder)).toBe(TOTAL_SQUARES - 1);
+		});
+
+		it("colors はすべて '#' で始まる hex 文字列", () => {
+			const { colors } = getDotArt(3);
+			expect(colors.every((c) => /^#[0-9a-fA-F]{6}$/.test(c))).toBe(true);
+		});
+	});
+
+	describe("MARCH_PATTERN データ整合性", () => {
+		it("パターンが 24 行ある", () => {
+			// colors = 576 件 = 24行 × 24列
+			const { colors } = getDotArt(3);
+			expect(colors).toHaveLength(GRID_SIZE * GRID_SIZE);
+		});
+
+		it("各行が 24 文字（parsePattern で正確に展開されている）", () => {
+			// colors の件数が576なら、各行24文字で正しくパースされている証拠
+			const { colors } = getDotArt(3);
+			// 行ごとに分割して各行24件であることを確認
+			for (let row = 0; row < GRID_SIZE; row++) {
+				const rowColors = colors.slice(row * GRID_SIZE, (row + 1) * GRID_SIZE);
+				expect(rowColors).toHaveLength(GRID_SIZE);
+			}
+		});
+	});
+});

--- a/src/core/dotArt.ts
+++ b/src/core/dotArt.ts
@@ -1,0 +1,61 @@
+const PALETTE: Record<string, string> = {
+	".": "#fef9c3", // 背景（薄黄）
+	R: "#dc2626", // 赤
+};
+
+// 祝（24×24）仮パターン
+const MARCH_PATTERN: string[] = [
+	"........................", //  0
+	".....R..................", //  1
+	".....R..................", //  2
+	"........................", //  3
+	".RRRRRRRRRR..RRRRRRRRRR.", //  4  礻横画 + 兄「口」上
+	".....R.......R........R.", //  5
+	".....R.......R........R.", //  6
+	".....R.......R........R.", //  7
+	".RRRRR.RRRR..RRRRRRRRRR.", //  8  礻左右払い + 兄「口」下
+	".....R...........R......", //  9
+	".....R...........R......", // 10
+	".....R...........R......", // 11
+	".....R...........R......", // 12
+	"...R.R.R.........R......", // 13  礻下点
+	"...R.R.R.........R......", // 14
+	".....R..........R.R.....", // 15  儿 脚分岐
+	".....R.........R...R....", // 16
+	".....R........R.....R...", // 17
+	".....R.......R.......R..", // 18
+	".....R.......R.......R..", // 19
+	".....R.......R.......R..", // 20
+	".....R.......R.......R..", // 21
+	"........................", // 22
+	"........................", // 23
+];
+
+function parsePattern(rows: string[]): string[] {
+	return rows.flatMap((row) => row.split("").map((ch) => PALETTE[ch] ?? PALETTE["."]));
+}
+
+function generateFillOrder(seed: number, size: number): number[] {
+	const arr = Array.from({ length: size }, (_, i) => i);
+	let s = seed;
+	for (let i = size - 1; i > 0; i--) {
+		s = (s * 48271) % 2147483647;
+		const j = s % (i + 1);
+		[arr[i], arr[j]] = [arr[j], arr[i]];
+	}
+	return arr;
+}
+
+export type MonthDotArt = {
+	colors: string[]; // 576件、グリッド順（行優先）の色
+	fillOrder: number[]; // 576件、埋める順番（値=グリッドインデックス）
+};
+
+const MARCH_DOT_ART: MonthDotArt = {
+	colors: parsePattern(MARCH_PATTERN),
+	fillOrder: generateFillOrder(3, 576),
+};
+
+export function getDotArt(_month: number): MonthDotArt {
+	return MARCH_DOT_ART;
+}

--- a/src/core/pointCard.test.ts
+++ b/src/core/pointCard.test.ts
@@ -1,98 +1,108 @@
 import { describe, it, expect } from "vitest";
-import { calcPointCard } from "./pointCard";
+import { calcPointCard, calcPreOpened, PTS_PER_SQUARE, TOTAL_SQUARES } from "./pointCard";
+
+const YEAR = 2026;
+const MONTH_MAR = 3; // 31日 → preOpened=0
+const MONTH_FEB = 2; // 28日 → preOpened=16
+
+describe("calcPreOpened", () => {
+	it("3月（31日）はpreOpenedが0", () => {
+		expect(calcPreOpened(YEAR, MONTH_MAR)).toBe(0);
+	});
+
+	it("2月平年（28日）はpreOpenedが16", () => {
+		// maxFillable = floor(28 * 100 / 5) = 560, preOpened = 576 - 560 = 16
+		expect(calcPreOpened(2025, MONTH_FEB)).toBe(16);
+	});
+
+	it("2月閏年（29日）はpreOpenedが0", () => {
+		// maxFillable = floor(29 * 100 / 5) = 580 > 576, preOpened = 0
+		expect(calcPreOpened(2024, MONTH_FEB)).toBe(0);
+	});
+
+	it("4月（30日）はpreOpenedが0", () => {
+		// maxFillable = floor(30 * 100 / 5) = 600 > 576, preOpened = 0
+		expect(calcPreOpened(YEAR, 4)).toBe(0);
+	});
+});
 
 describe("calcPointCard", () => {
-	describe("最終ご褒美 200pt（横1行ぴったり）", () => {
-		const rewards = [{ id: "1", label: "ケーキ", points: 200 }];
-
-		it("totalSquares が 8 になる", () => {
-			const { totalSquares } = calcPointCard(0, rewards);
-			expect(totalSquares).toBe(8);
+	describe("基本構造", () => {
+		it("totalSquares が 576 になる", () => {
+			const { totalSquares } = calcPointCard(0, [], YEAR, MONTH_MAR);
+			expect(totalSquares).toBe(TOTAL_SQUARES);
 		});
 
-		it("行数が 1 になる", () => {
-			const { rows } = calcPointCard(0, rewards);
-			expect(rows).toHaveLength(1);
-		});
-
-		it("1行目が 8 マスになる", () => {
-			const { rows } = calcPointCard(0, rewards);
-			expect(rows[0].squares).toHaveLength(8);
-		});
-
-		it("最終マス（index 7）にご褒美が配置される", () => {
-			const { rows } = calcPointCard(0, rewards);
-			expect(rows[0].squares[7].reward?.label).toBe("ケーキ");
-		});
-
-		it("200pt 達成時に全マス埋まる", () => {
-			const { filledSquares, totalSquares } = calcPointCard(200, rewards);
-			expect(filledSquares).toBe(totalSquares);
+		it("squares が 576 件になる", () => {
+			const { squares } = calcPointCard(0, [], YEAR, MONTH_MAR);
+			expect(squares).toHaveLength(TOTAL_SQUARES);
 		});
 	});
 
-	describe("最終ご褒美 250pt（2行目途中で終わる）", () => {
-		const rewards = [{ id: "1", label: "旅行", points: 250 }];
-
-		it("totalSquares が 10 になる", () => {
-			const { totalSquares } = calcPointCard(0, rewards);
-			expect(totalSquares).toBe(10);
+	describe("3月（preOpened=0）", () => {
+		it("0pt では何も埋まらない", () => {
+			const { filledByPoints, squares } = calcPointCard(0, [], YEAR, MONTH_MAR);
+			expect(filledByPoints).toBe(0);
+			expect(squares.filter((s) => s.filled)).toHaveLength(0);
 		});
 
-		it("行数が 2 になる", () => {
-			const { rows } = calcPointCard(0, rewards);
-			expect(rows).toHaveLength(2);
+		it(`${PTS_PER_SQUARE}pt で 1マス埋まる`, () => {
+			const { filledByPoints } = calcPointCard(PTS_PER_SQUARE, [], YEAR, MONTH_MAR);
+			expect(filledByPoints).toBe(1);
 		});
 
-		it("1行目が 8 マスになる", () => {
-			const { rows } = calcPointCard(0, rewards);
-			expect(rows[0].squares).toHaveLength(8);
+		it("100pt で 20マス埋まる", () => {
+			const { filledByPoints } = calcPointCard(100, [], YEAR, MONTH_MAR);
+			expect(filledByPoints).toBe(20);
 		});
 
-		it("2行目が 2 マスになる（余白なし）", () => {
-			const { rows } = calcPointCard(0, rewards);
-			expect(rows[1].squares).toHaveLength(2);
-		});
-
-		it("最終マス（index 9）にご褒美が配置される", () => {
-			const { rows } = calcPointCard(0, rewards);
-			expect(rows[1].squares[1].reward?.label).toBe("旅行");
-		});
-
-		it("250pt 達成時に全マス埋まる", () => {
-			const { filledSquares, totalSquares } = calcPointCard(250, rewards);
-			expect(filledSquares).toBe(totalSquares);
+		it("2880pt（5pt×576）で全マスが埋まる", () => {
+			const { filledByPoints, squares } = calcPointCard(
+				PTS_PER_SQUARE * TOTAL_SQUARES,
+				[],
+				YEAR,
+				MONTH_MAR,
+			);
+			expect(filledByPoints).toBe(TOTAL_SQUARES);
+			expect(squares.filter((s) => s.filled)).toHaveLength(TOTAL_SQUARES);
 		});
 	});
 
-	describe("最終ご褒美 10000pt", () => {
-		const rewards = [{ id: "1", label: "海外旅行", points: 10000 }];
-
-		it("totalSquares が 400 になる", () => {
-			const { totalSquares } = calcPointCard(0, rewards);
-			expect(totalSquares).toBe(400);
+	describe("2月平年（preOpened=16）", () => {
+		it("0pt でも 16マス埋まっている", () => {
+			const { preOpened, squares } = calcPointCard(0, [], 2025, MONTH_FEB);
+			expect(preOpened).toBe(16);
+			expect(squares.filter((s) => s.filled)).toHaveLength(16);
 		});
 
-		it("行数が 50 になる", () => {
-			const { rows } = calcPointCard(0, rewards);
-			expect(rows).toHaveLength(50);
+		it("ポイントで埋められる最大は 560マス", () => {
+			const { filledByPoints } = calcPointCard(
+				PTS_PER_SQUARE * TOTAL_SQUARES,
+				[],
+				2025,
+				MONTH_FEB,
+			);
+			expect(filledByPoints).toBe(TOTAL_SQUARES - 16);
+		});
+	});
+
+	describe("ランダム埋め順", () => {
+		it("fillOrder は 576 件", () => {
+			const { fillOrder } = calcPointCard(0, [], YEAR, MONTH_MAR);
+			expect(fillOrder).toHaveLength(TOTAL_SQUARES);
 		});
 
-		it("全行が 8 マスになる", () => {
-			const { rows } = calcPointCard(0, rewards);
-			for (const row of rows) {
-				expect(row.squares).toHaveLength(8);
-			}
+		it("fillOrder は 0〜575 の各値を1回ずつ含む", () => {
+			const { fillOrder } = calcPointCard(0, [], YEAR, MONTH_MAR);
+			expect(new Set(fillOrder).size).toBe(TOTAL_SQUARES);
 		});
+	});
 
-		it("最終マス（index 399）にご褒美が配置される", () => {
-			const { rows } = calcPointCard(0, rewards);
-			expect(rows[49].squares[7].reward?.label).toBe("海外旅行");
-		});
-
-		it("10000pt 達成時に全マス埋まる", () => {
-			const { filledSquares, totalSquares } = calcPointCard(10000, rewards);
-			expect(filledSquares).toBe(totalSquares);
+	describe("squaresの色", () => {
+		it("埋まったマスは color が '#f3f4f6' でない（ドット絵カラー）", () => {
+			const { squares } = calcPointCard(PTS_PER_SQUARE, [], YEAR, MONTH_MAR);
+			const filled = squares.filter((s) => s.filled);
+			expect(filled.every((s) => s.color !== "#f3f4f6")).toBe(true);
 		});
 	});
 });

--- a/src/core/pointCard.ts
+++ b/src/core/pointCard.ts
@@ -1,6 +1,9 @@
-export const COLS = 8;
-export const PTS_PER_SQUARE = 25;
-export const PTS_PER_ROW = COLS * PTS_PER_SQUARE; // 200
+import { getDotArt } from "./dotArt";
+import type { MonthDotArt } from "./dotArt";
+
+export const GRID_SIZE = 24;
+export const TOTAL_SQUARES = GRID_SIZE * GRID_SIZE; // 576
+export const PTS_PER_SQUARE = 5;
 
 export type Reward = {
 	id: string;
@@ -10,47 +13,61 @@ export type Reward = {
 
 export type SquareState = {
 	filled: boolean;
-	reward: Reward | null;
-};
-
-export type RowState = {
-	squares: SquareState[];
+	color: string;
 };
 
 export type PointCardState = {
-	filledSquares: number;
+	filledByPoints: number;
+	preOpened: number;
 	totalSquares: number;
-	rows: RowState[];
+	squares: SquareState[];
+	fillOrder: number[];
 };
 
-export function calcPointCard(currentPoints: number, rewards: Reward[]): PointCardState {
-	const maxPoints = rewards.length > 0
-		? Math.max(...rewards.map((r) => r.points))
-		: 500;
+function getDaysInMonth(year: number, month: number): number {
+	return new Date(year, month, 0).getDate();
+}
 
-	const maxSquareIndex = Math.ceil(maxPoints / PTS_PER_SQUARE) - 1;
-	const totalSquares = maxSquareIndex + 1;
-	const totalRows = Math.ceil(totalSquares / COLS);
-	const filledSquares = Math.floor(currentPoints / PTS_PER_SQUARE);
+export function calcPreOpened(year: number, month: number): number {
+	const days = getDaysInMonth(year, month);
+	const maxFillable = Math.floor((days * 100) / PTS_PER_SQUARE);
+	return Math.max(0, TOTAL_SQUARES - maxFillable);
+}
 
-	const rewardBySquare = new Map<number, Reward>();
-	for (const reward of rewards) {
-		const squareIndex = Math.ceil(reward.points / PTS_PER_SQUARE) - 1;
-		rewardBySquare.set(squareIndex, reward);
+export function calcPointCard(
+	currentPoints: number,
+	_rewards: Reward[],
+	year?: number,
+	month?: number,
+): PointCardState {
+	const now = new Date();
+	const y = year ?? now.getFullYear();
+	const m = month ?? now.getMonth() + 1;
+
+	const dotArt: MonthDotArt = getDotArt(m);
+	const preOpened = calcPreOpened(y, m);
+
+	const filledByPoints = Math.min(
+		Math.floor(currentPoints / PTS_PER_SQUARE),
+		TOTAL_SQUARES - preOpened,
+	);
+	const totalFilled = preOpened + filledByPoints;
+
+	const fillPosition = new Array<number>(TOTAL_SQUARES);
+	for (let i = 0; i < TOTAL_SQUARES; i++) {
+		fillPosition[dotArt.fillOrder[i]] = i;
 	}
 
-	const rows: RowState[] = Array.from({ length: totalRows }, (_, rowIndex) => {
-		const rowStart = rowIndex * COLS;
-		const rowEnd = Math.min(rowStart + COLS, totalSquares);
-		const squares: SquareState[] = Array.from({ length: rowEnd - rowStart }, (_, colIndex) => {
-			const squareIndex = rowStart + colIndex;
-			return {
-				filled: squareIndex < filledSquares,
-				reward: rewardBySquare.get(squareIndex) ?? null,
-			};
-		});
-		return { squares };
-	});
+	const squares: SquareState[] = Array.from({ length: TOTAL_SQUARES }, (_, gridIndex) => ({
+		filled: fillPosition[gridIndex] < totalFilled,
+		color: dotArt.colors[gridIndex],
+	}));
 
-	return { filledSquares, totalSquares, rows };
+	return {
+		filledByPoints,
+		preOpened,
+		totalSquares: TOTAL_SQUARES,
+		squares,
+		fillOrder: dotArt.fillOrder,
+	};
 }


### PR DESCRIPTION
## 概要

Issue #36 の実装。ポイントカードをランダム埋め＋ドット絵リビール方式に変更。

## 変更内容

- **カードサイズ**: 8列×N行 → 24×24=576マス固定
- **埋め方**: 順番埋め → ランダム順（シード付き決定的シャッフル）
- **1マスのpt**: 25pt → 5pt（月完走で576マス全開放）
- **初期開放**: 平年2月のみ16マスをpreOpenedとして月初から開放
- **ドット絵**: 「祝」仮パターンを追加（`src/core/dotArt.ts`）、月別テーマは今後追加
- **ご褒美一覧**: 達成度プログレスバーを追加（未達成: 現在pt/目標pt、達成: 緑で「達成！」）

## テスト

- `src/core/dotArt.test.ts` 新規追加（6テスト）
- `src/core/pointCard.test.ts` 更新（15テスト）

## 今後の作業

- 月別ドット絵を Piskel で描いて `dotArt.ts` に追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)