### PR TITLE
fix: ゴール・中間マイルストーンの日付削除を無効化

### DIFF
--- a/src/app/goal/page.tsx
+++ b/src/app/goal/page.tsx
@@ -264,7 +264,9 @@ export default function GoalPage() {
 									<span className="text-sm text-gray-700">{editStepForm.scheduled_date}</span>
 									<div className="flex gap-3">
 										<button type="button" onClick={() => setShowDatePicker(true)} className="text-xs text-indigo-500">変更</button>
-										<button type="button" onClick={() => { setEditStepForm((f) => ({ ...f, scheduled_date: "" })); setShowDatePicker(false); }} className="text-xs text-red-400">削除</button>
+										{!editingStep?.is_milestone && (
+											<button type="button" onClick={() => { setEditStepForm((f) => ({ ...f, scheduled_date: "" })); setShowDatePicker(false); }} className="text-xs text-red-400">削除</button>
+										)}
 									</div>
 								</div>
 							) : showDatePicker ? (


### PR DESCRIPTION
## Summary

- `is_milestone: true` のステップ編集時に「削除」ボタンを非表示にした
- 日付の「変更」は引き続き可能

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)